### PR TITLE
Added functions that automatically resize the xwidget in the window

### DIFF
--- a/nov-xwidget.el
+++ b/nov-xwidget.el
@@ -527,5 +527,23 @@ Interactively, URL defaults to the string looking like a url around point."
       (setq-local nov-toc-id toc)
       (setq-local nov-epub-version epub))))
 
+; Window size change functions; this arrangement below is not ideal, as it basically replicates the code in xwidget-webkit.el, which changes the size of the xwidget *if* the window's mode is xwidget-webkit-mode.
+; In the future, xwidget-webkit should accomodate generalized "windows containing a webkit instance" rather than just xwidget-webkit-mode specifically for this.
+
+(defun nov-xwidget-webkit-auto-adjust-size (window)
+  "Adjust the size of the webkit widget in the given nov-webkit WINDOW."
+  (with-current-buffer (window-buffer window)
+    (when (eq major-mode 'nov-xwidget-webkit-mode)
+      (let ((xwidget (xwidget-webkit-current-session)))
+        (xwidget-webkit-adjust-size-to-window xwidget window)))))
+
+(defun nov-xwidget-webkit-adjust-size-in-frame (frame)
+  "Dynamically adjust webkit widget for all nov-webkit windows of the FRAME."
+  (walk-windows 'nov-xwidget-webkit-auto-adjust-size 'no-minibuf frame))
+
+(eval-after-load 'nov-xwidget-webkit-mode
+  (add-to-list 'window-size-change-functions
+               'nov-xwidget-webkit-adjust-size-in-frame))
+
 (provide 'nov-xwidget)
 ;;; nov-xwidget.el ends here


### PR DESCRIPTION
Hello; I understand if this request isn't accepted as it's a bit of an inelegant solution.

Basically, `xwidget-webkit-mode` automatically resizes the webkit widget by adding `xwidget-webkit-adjust-size-in-frame` to the list `window-size-change-functions`; the problem is that this function calls `xwidget-webkit-auto-adjust-size` which only adjusts windows in `xwidget-webkit-mode`. Since our mode has a different name, the window isn't resized properly. So we need these functions to also check for windows in *our* mode and resize them.

This fixes the issue, but I could see this being an issue with `xwidget-webkit` in the long term as more and more emacs packages rely on webkit and have their own (near identical) resize functions. From the user perspective there's no performance consequences to this and it works fine, of course.